### PR TITLE
Add build agent docker file

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,9 +71,9 @@ pipeline {
       }
       steps {
         sh '''
-           npm ci
+           npm ci --no-cache
            npm run build
-           ./mvnw package
+           mvn package
            docker build -f src/main/docker/Dockerfile.jvm --no-cache -t ${IMAGE_NAME}:${TAG_NAME} -t ${IMAGE_NAME}:latest .
         '''
       }

--- a/src/main/docker/Dockerfile.agent
+++ b/src/main/docker/Dockerfile.agent
@@ -6,8 +6,7 @@
 FROM fabric8/java-alpine-openjdk11-jre
 
 # add mvn, npm, nodejs, hugo
-RUN apk update
-RUN apk add --no-cache\
+RUN apk add --update --no-cache\
   npm \
   nodejs \
   maven \
@@ -15,6 +14,6 @@ RUN apk add --no-cache\
   tar
 
 WORKDIR /tmp
-RUN wget -qO- https://github.com/gohugoio/hugo/releases/download/v0.62.2/hugo_0.62.2_Linux-64bit.tar.gz | tar xvz - -C /bin/
+RUN wget -qO- https://github.com/gohugoio/hugo/releases/download/v0.62.2/hugo_0.62.2_Linux-64bit.tar.gz | tar xvz -C /bin/
 
-CMD ["jshell"]
+ENTRYPOINT [ "/bin/sh" ]

--- a/src/main/docker/Dockerfile.agent
+++ b/src/main/docker/Dockerfile.agent
@@ -1,0 +1,20 @@
+####
+#
+# Create a base image for building web+java properties. Add support for nodeJS, NPM, and mvn
+#
+####
+FROM fabric8/java-alpine-openjdk11-jre
+
+# add mvn, npm, nodejs, hugo
+RUN apk update
+RUN apk add --no-cache\
+  npm \
+  nodejs \
+  maven \
+  wget \
+  tar
+
+WORKDIR /tmp
+RUN wget -qO- https://github.com/gohugoio/hugo/releases/download/v0.62.2/hugo_0.62.2_Linux-64bit.tar.gz | tar xvz - -C /bin/
+
+CMD ["jshell"]


### PR DESCRIPTION
This build agent enables the usage of nodejs, npm, hugo, and maven in a
Java Alpine linux container.

Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>