### PR TITLE
Update to fix wrong scheme being passed back for proxied requests

### DIFF
--- a/js/eclipsefdn.adopters.js
+++ b/js/eclipsefdn.adopters.js
@@ -94,7 +94,7 @@
 
         // check the link header as long as its set
         var linkHeader = xhttp.getResponseHeader('Link');
-        if (linkHeader !== null) {
+        if (linkHeader !== undefined) {
           var match = linkHeader.match(precompiledRegex);
           // if there is no match, then there is no next and we are on the last page and should process data through callback
           if (match !== null) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,3 +10,4 @@ quarkus.http.cors=false
 ## Adopters raw location
 eclipse.adopters.path.json=/config/adopters.json
 %dev.eclipse.adopters.path.json=/tmp/config/adopters.json
+%dev.eclipse.pagination.scheme.enforce=false


### PR DESCRIPTION
When requests are being proxied, the internal HTTP calls are being used
to create Link headers. This leads to bounced requests when proxies are
delegating HTTPS requests to the internal HTTP server. In the future, we
should secure this server and bypass the issue that way.

Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>