### PR TITLE
Revert CORS properties

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,8 +5,7 @@ quarkus.http.port=8080
 quarkus.http.root-path=/adopters
 
 ## CORS settings
-quarkus.http.cors=true
-quarkus.http.cors.exposed-headers=Etag,Link,Content-Type
+quarkus.http.cors=false
 
 ## Adopters raw location
 eclipse.adopters.path.json=/config/adopters.json


### PR DESCRIPTION
Nginx was caching responses from the server w/ headers as it wasn't
aware of CORS headers. To fix issues + keep HTTP caching, CORS
management has been moved back to Nginx conf.

Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>