### PR TITLE
alphabetical order for adopter logos #35

### DIFF
--- a/config/adopters.json
+++ b/config/adopters.json
@@ -633,6 +633,17 @@
 				"iot.cyclonedds"
 			]
 		},
+    {
+      "name": "Tractonomy Robotics",
+      "homepage_url": "https://www.tractonomy.com",
+      "logo": "logo-tractonomy-robotics.png",
+      "logo_white": "logo-tractonomy-robotics-white.png",
+      "projects": [
+        "iot.cyclonedds",
+        "technology.iceoryx",
+        "iot.zenoh"
+      ]
+    },
 		{
 			"name": "Trajekt Sports Inc.",
 			"homepage_url": "http://www.trajektsports.com",
@@ -667,18 +678,7 @@
 			"logo_white": "logo-verizon-white.svg",
 			"projects": [
 				"iot.leshan"
-                        ]
-		},
-		{
-			"name": "Tractonomy Robotics",
-			"homepage_url": "https://www.tractonomy.com",
-			"logo": "logo-tractonomy-robotics.png",
-			"logo_white": "logo-tractonomy-robotics-white.png",
-			"projects": [
-				"iot.cyclonedds",
-				"technology.iceoryx",
-				"iot.zenoh"
-			]
+      ]
 		}
 	]
 }

--- a/config/adopters.json
+++ b/config/adopters.json
@@ -49,6 +49,17 @@
 				"iot.hono"
 			]
 		},
+    {
+      "name": "Ampere Computing LLC.",
+      "homepage_url": "https://amperecomputing.com/",
+      "logo": "logo-amperecomputing.png",
+      "logo_white": "logo-amperecomputing-white.png",
+      "projects": [
+        "iot.cyclonedds",
+        "technology.iceoryx",
+        "iot.zenoh"
+      ]
+    },
 		{
 			"name": "AutoCore.ai",
 			"homepage_url": "http://www.autocore.ai/",
@@ -260,6 +271,15 @@
 				"ecd.theia"
 			]
 		},
+    {
+      "name": "Hadabot",
+      "homepage_url": "https://www.hadabot.com/",
+      "logo": "logo-hadabot.png",
+      "logo_white": "logo-hadabot-white.png",
+      "projects": [
+        "iot.cyclonedds"
+      ]
+    },
 		{
 			"name": "Hawai'i - AVTech",
 			"homepage_url": "https://www.HawaiiAVTech.com",
@@ -647,27 +667,7 @@
 			"logo_white": "logo-verizon-white.svg",
 			"projects": [
 				"iot.leshan"
-			]
-		},
-		{
-			"name": "Hadabot",
-			"homepage_url": "https://www.hadabot.com/",
-			"logo": "logo-hadabot.png",
-			"logo_white": "logo-hadabot-white.png",
-			"projects": [
-				"iot.cyclonedds"
-			]
-		},
-		{
-			"name": "Ampere Computing LLC.",
-			"homepage_url": "https://amperecomputing.com/",
-			"logo": "logo-amperecomputing.png",
-			"logo_white": "logo-amperecomputing-white.png",
-			"projects": [
-				"iot.cyclonedds",
-				"technology.iceoryx",
-				"iot.zenoh"
-			]
+                        ]
 		},
 		{
 			"name": "Tractonomy Robotics",

--- a/src/main/java/org/eclipsefoundation/adopters/service/impl/DefaultAdopterService.java
+++ b/src/main/java/org/eclipsefoundation/adopters/service/impl/DefaultAdopterService.java
@@ -43,6 +43,8 @@ import org.eclipsefoundation.adopters.service.AdopterService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.collect.Comparators;
+
 import io.quarkus.runtime.Startup;
 
 /**
@@ -206,8 +208,13 @@ public class DefaultAdopterService implements AdopterService {
 		ap.setName(p.getName());
 		ap.setLogo(p.getLogo());
 		ap.setUrl(p.getUrl());
-		ap.setAdopters(getAdopters().stream().filter(a -> a.getProjects().contains(p.getProjectId()))
-				.collect(Collectors.toList()));
+		List<Adopter> projAdopters = getAdopters().stream().filter(a -> a.getProjects().contains(p.getProjectId()))
+                .collect(Collectors.toList());
+		// natural sort by name field
+		projAdopters.sort((o1, o2) -> 
+		    o1.getName().toLowerCase().compareTo(o2.getName().toLowerCase())
+		);
+		ap.setAdopters(projAdopters);
 		return ap;
 	}
 

--- a/src/main/java/org/eclipsefoundation/adopters/service/impl/DefaultAdopterService.java
+++ b/src/main/java/org/eclipsefoundation/adopters/service/impl/DefaultAdopterService.java
@@ -25,6 +25,7 @@ import java.nio.file.WatchKey;
 import java.nio.file.WatchService;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -42,8 +43,6 @@ import org.eclipsefoundation.adopters.model.Project;
 import org.eclipsefoundation.adopters.service.AdopterService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.collect.Comparators;
 
 import io.quarkus.runtime.Startup;
 
@@ -207,14 +206,9 @@ public class DefaultAdopterService implements AdopterService {
 		ap.setProjectId(p.getProjectId());
 		ap.setName(p.getName());
 		ap.setLogo(p.getLogo());
-		ap.setUrl(p.getUrl());
-		List<Adopter> projAdopters = getAdopters().stream().filter(a -> a.getProjects().contains(p.getProjectId()))
-                .collect(Collectors.toList());
-		// natural sort by name field
-		projAdopters.sort((o1, o2) -> 
-		    o1.getName().toLowerCase().compareTo(o2.getName().toLowerCase())
-		);
-		ap.setAdopters(projAdopters);
+        ap.setUrl(p.getUrl());
+        ap.setAdopters(getAdopters().stream().filter(a -> a.getProjects().contains(p.getProjectId()))
+                .sorted(Comparator.comparing(a -> a.getName().toLowerCase())).collect(Collectors.toList()));
 		return ap;
 	}
 


### PR DESCRIPTION
Fixed JSON order + add natural sorting to list of adopters for project.
Maintaining sort order in file is purely for ease of organization and
maintaining large list of adopters.

Fixes #35

Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>