### PR TITLE
documentation: fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,14 @@ Adopters are organizations that voluntarily show their support for the Eclipse p
 
 You can add your organization logo to our list of adopters by submitting a pull request or by creating an [issue](https://github.com/EclipseFdn/eclipsefdn-project-adopters/issues/new?template=adopter_request.md). You can attach files to an issue by dragging and dropping them in the text editor of the form.
 
-If you plan on submitting a pull request, you will need to make the following changes to the website's codebase: 
+If you plan on submitting a pull request, you will need to make the following changes to the website's codebase:
 
-1. Add a colored and a white organization logo to static/assets/images/adoptors. We expect that all submitted logos to be transparent svg and compressed for web.  
-2. Update the adopter JSON file: [config/adopters.json](https://github.com/EclipseFdn/eclipsefdn-project-adopters/blob/master/config/adopters.json). Organizations can be easily marked as having multiple adopted projects across different working groups, no need to create separate entries for different projects or working groups!  
+1. Add a colored and a white organization logo to static/assets/images/adopters. We expect that all submitted logos to be transparent svg and compressed for web.
+2. Update the adopter JSON file: [config/adopters.json](https://github.com/EclipseFdn/eclipsefdn-project-adopters/blob/master/config/adopters.json). Organizations can be easily marked as having multiple adopted projects across different working groups, no need to create separate entries for different projects or working groups!
 
-### Javascript Plugin 
+### Javascript Plugin
 
-Eclipse projects can showcase the logos of their adopters on their project websites. We built a JavaScript plugin to make this process easier. If you are a project committer, here are quick instructions on how to use the eclipsefdn-adopters.js on your Eclipse projet website:
+Eclipse projects can showcase the logos of their adopters on their project websites. We built a JavaScript plugin to make this process easier. If you are a project committer, here are quick instructions on how to use the eclipsefdn-adopters.js on your Eclipse project website:
 
 #### Usage
 

--- a/content/how-to-be-listed-as-an-adopter/_index.md
+++ b/content/how-to-be-listed-as-an-adopter/_index.md
@@ -6,11 +6,11 @@ layout: "single"
 
 Does your organization use Eclipse projects? Organizations — whether they are members of the Eclipse Foundation or not — can be listed as Eclipse technology adopters.
 
-Adopters are organizations that voluntarily show their support for the Eclipse projects they have adopted (i.e. shipping commercial products based on the projects and/or using the projects for non-commercial or internal reasons). 
+Adopters are organizations that voluntarily show their support for the Eclipse projects they have adopted (i.e. shipping commercial products based on the projects and/or using the projects for non-commercial or internal reasons).
 
 You can add your organization logo to our list of adopters by submitting a pull request or by creating an [issue](https://github.com/EclipseFdn/eclipsefdn-project-adopters/issues/new?template=adopter_request.md). You can attach files to an issue by dragging and dropping them in the text editor of the form.
 
-If you plan on submitting a pull request, you will need to make the following changes to the website's codebase: 
+If you plan on submitting a pull request, you will need to make the following changes to the website's codebase:
 
-1. Add a colored and a white organization logo to static/assets/images/adoptors. We expect that all submitted logos to be transparent svg and compressed for web.
+1. Add a colored and a white organization logo to static/assets/images/adopters. We expect that all submitted logos to be transparent svg and compressed for web.
 2. Update the adopter JSON file: [config/adopters.json](https://github.com/EclipseFdn/eclipsefdn-project-adopters/blob/master/config/adopters.json). Organizations can be easily marked as having multiple adopted projects across different working groups, no need to create separate entries for different projects or working groups!


### PR DESCRIPTION
**What it does**:

The following pull-request fixes typos found in the documentation which was noticed when attempting to add an `adopter` listing following the documentation from: https://ecdtools.eclipse.org/adopters/how-to-be-listed-as-an-adopter/.

The typo referenced in the documentation is `static/assets/images/adoptors` which should be `static/assets/images/adopters` based on the path:
- https://github.com/EclipseFdn/eclipsefdn-project-adopters/tree/master/static/assets/images/adopters



Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>