### PR TITLE
Fix for dockerfile agent to include nghttp2

### DIFF
--- a/src/main/docker/Dockerfile.agent
+++ b/src/main/docker/Dockerfile.agent
@@ -3,11 +3,12 @@
 # Create a base image for building web+java properties. Add support for nodeJS, NPM, and mvn
 #
 ####
-FROM fabric8/java-alpine-openjdk11-jre
+FROM alpine:3.12
 
 # add mvn, npm, nodejs, hugo
 RUN apk add -U --upgrade nghttp2
 RUN apk add --update --no-cache\
+  openjdk11-jre \
   npm \
   nodejs \
   maven \

--- a/src/main/docker/Dockerfile.agent
+++ b/src/main/docker/Dockerfile.agent
@@ -6,11 +6,11 @@
 FROM alpine:3.12
 
 # add mvn, npm, nodejs, hugo
-RUN apk add -U --upgrade nghttp2
 RUN apk add --update --no-cache\
   openjdk11-jre \
   npm \
   nodejs \
+  nghttp2 \
   maven \
   wget \
   tar

--- a/src/main/docker/Dockerfile.agent
+++ b/src/main/docker/Dockerfile.agent
@@ -6,6 +6,7 @@
 FROM fabric8/java-alpine-openjdk11-jre
 
 # add mvn, npm, nodejs, hugo
+RUN apk add -U --upgrade nghttp2
 RUN apk add --update --no-cache\
   npm \
   nodejs \


### PR DESCRIPTION
Issue with current stable image not properly including nghttp2, which
can be fixed by adding explicitly + upgrading.

Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>