### PR TITLE
Add back missing test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,9 @@
     "build_netlify": "npm run production && npm run disallow_robots_txt",
     "minify_adopters": "mkdir -p target/config && ./node_modules/json-minify/index.js config/adopters.json > target/config/adopters.json",
     "dev": "NODE_ENV=development webpack --progress --config=node_modules/laravel-mix/setup/webpack.config.js",
-    "production": "NODE_ENV=production webpack --progress --config=node_modules/laravel-mix/setup/webpack.config.js",
-    "disallow_robots_txt": "echo \"User-agent: *\r\nDisallow: /\" > layouts/robots.txt"
+    "production": "NODE_ENV=production webpack --progress --config=node_modules/laravel-mix/setup/webpack.config.js && npm run adopters_json && npm run test",
+    "disallow_robots_txt": "echo \"User-agent: *\r\nDisallow: /\" > layouts/robots.txt",
+    "adopters_json": "cp config/adopters.json static/assets/js"
   },
   "dependencies": {
     "chai": "^4.2.0",


### PR DESCRIPTION
Seems the test json script and creating test adopters.json file script are missing when merging with another PR.

Signed-off-by: Yi Liu <yi.liu@eclipse-foundation.org>