### PR TITLE
Fixed link for Bosch.IO projects

### DIFF
--- a/config/adopters.json
+++ b/config/adopters.json
@@ -109,7 +109,7 @@
 		},
 		{
 			"name": "Bosch.IO",
-			"homepage_url": "https://www.bosch-iot-suite.com/service/hub/",
+			"homepage_url": "https://bosch-iot-suite.com",
 			"logo": "logo-bosch.svg",
 			"logo_white": "logo-bosch-white.svg",
 			"projects": [


### PR DESCRIPTION
The existing link pointed to "Hub" which is not valid for all Bosch.IO projects - pointed to https://bosch-iot-suite.com which is the entry point for all Bosch.IO commercial adoptions of the Eclipse IoT projects.